### PR TITLE
Fix typo & update workspace visibility

### DIFF
--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -34,7 +34,7 @@
 
 <div class="flex flex-col w-full items-start">
 	{#each selectedModels as selectedModel, selectedModelIdx}
-		<div class="flex w-full {models.length > 6 ? 'max-w-fit': ''}">
+		<div class="flex w-full {$models.length > 6 ? 'max-w-fit': ''}">
 			<div class="overflow-hidden w-full">
 				<div class="mr-1 max-w-full">
 					<Selector

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -76,7 +76,7 @@
 	let chatListLoading = false;
 	let allChatsLoaded = false;
 
-	let workspaceDisabled = true;
+	let workspaceDisabled = $user?.role !== 'admin';
 
 	let folders = {};
 


### PR DESCRIPTION
1) Fixing typo - missing dollar sign. The DropdownMenu shouldn't use full width

Before
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/42145d74-7654-4466-a8a0-4b1b6741077f" />

After
<img width="1578" alt="image" src="https://github.com/user-attachments/assets/eafd1325-0496-4934-bd95-5a62c64307ad" />

2) disable workspace only for non-admin
Admin
<img width="512" alt="image" src="https://github.com/user-attachments/assets/322c6e87-53f3-44f4-a16d-8b77ae33ff3b" />

User
<img width="257" alt="image" src="https://github.com/user-attachments/assets/bef36237-7988-4c33-996e-d5faa9a5f0a0" />
