### PR TITLE
bypass invalid json error message naively

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -785,7 +785,7 @@
 									/>
 								{/if}
 
-								{#if message?.error}
+								{#if message?.error && !((message?.error?.content ?? message.content).includes('... is not valid JSON'))}
 									<Error content={message?.error?.content ?? message.content} />
 								{/if}
 


### PR DESCRIPTION
bypass invalid json error message naively
- can't test locally, only reproduceable in prod server